### PR TITLE
hide the RidingSkill log behind debug mode

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -91,7 +91,10 @@ local function GetRidingSkill()
   if IsPlayerSpell(34091, false) then--300
     ridingSkill = 300
   end
-  print("RidingSkill: " .. tostring(ridingSkill))
+
+  if inDebugMode then
+    print("RidingSkill: " .. tostring(ridingSkill))
+  end
 end
 
 --Create delay function


### PR DESCRIPTION
I noticed since the last update the RidingSkill kept printing to the chat box. This small tweak hides it unless the addon is in debug mode

![image](https://user-images.githubusercontent.com/5769389/199854772-f11b6058-aac2-4418-a828-eaff03381ad1.png)