### PR TITLE
fix mount spell name

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -436,7 +436,8 @@ local function UpdateMyMounts()
 
     if (playerFaction == "Alliance" and (faction == nil or faction == 1)) or (playerFaction == "Horde" and (faction == nil or faction == 0)) then --Correct Faction
       if isCollected and not shouldHideOnChar then --Have mount and usable on character
-        mount = {creatureSpellID, name, mountID, isGroundMount, isFlyingMount, isSwimmingMount, category, isFavorite}
+        mountSpellName, _, _, _, _, _ = GetSpellInfo(spellID);
+        mount = {creatureSpellID, mountSpellName, mountID, isGroundMount, isFlyingMount, isSwimmingMount, category, isFavorite}
         table.insert(myMounts["KnownMounts"], mount)
         if isUsable then --Usable in current zone -- or (inDalaran and isMultiSpeed)
           table.insert(myMounts["UsableMounts"], mount)


### PR DESCRIPTION
Some mount's name have different spellName. 

For example: 

Mount "X-45 Heartbreaker" in Russian localization have name ""Сердцеед" X-45", but spell have name "Большая ракета любви"

/cast "Сердцеед" X-45 - doesn't work
/cast Большая ракета любви - work success

P.S.: sorry for my English)